### PR TITLE
Sysop can be included in ddcallers

### DIFF
--- a/daydream-2.20.0/SRC/utils/ddcallers.c
+++ b/daydream-2.20.0/SRC/utils/ddcallers.c
@@ -97,6 +97,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'n':
 			node = atoi(optarg);
+			break;
 		case 'e':
 			incsysop = 0;
 			break;


### PR DESCRIPTION
I was trying to figure out why sysop wouldn't show up in ddcallers when I found this tiny bug.
